### PR TITLE
feat: implement /slidev:format and advanced v52+ directives (closes #7)

### DIFF
--- a/commands/slidev/edit.toml
+++ b/commands/slidev/edit.toml
@@ -1,5 +1,7 @@
 description = "Edit existing slides"
 prompt = """
+Before starting, activate the 'slidev' skill.
+
 I want to modify the existing slides.
 
 1. **Pre-check**:
@@ -13,9 +15,12 @@ I want to modify the existing slides.
    - Ask specifically what changes to make (styling, content, refactoring).
    - Suggest applying UnoCSS classes for styling (e.g., 'text-blue-500', 'flex', 'grid', 'font-serif').
    - Recommend adding animations (<v-click>, v-motion, <v-clicks>).
+   - **New Feature: Highlighter**:
+     - Suggest using the `v-mark` directive (e.g., `<v-mark color=\"red\">text</v-mark>`) to highlight specific words or sentences.
    - Offer to refactor long slides into multiple slides.
 
 4. **Apply Changes**:
    - Update 'slides.md' precisely, preserving the overall project structure.
-"""
 
+User specific request: {{args}}
+"""

--- a/commands/slidev/format.toml
+++ b/commands/slidev/format.toml
@@ -1,0 +1,18 @@
+description = "Format the slides markdown file using Prettier"
+prompt = """
+Before starting, activate the 'slidev' skill.
+
+I want to format the 'slides.md' file or any Slidev markdown file in the current directory.
+
+1. **Pre-check**:
+   - Verify if 'slides.md' exists in the current directory.
+   - If missing, inform me that no file was found to format.
+
+2. **Action**:
+   - Use the 'run_shell_command' to execute the formatting script:
+     `npm run format` (which calls 'prettier --write .')
+   - Alternatively, you can run `npx prettier --write slides.md` if the script is not found in 'package.json'.
+   - Inform me once the formatting is complete.
+
+User specific request: {{args}}
+"""

--- a/commands/slidev/generate.toml
+++ b/commands/slidev/generate.toml
@@ -1,5 +1,7 @@
 description = "Generate slides content from a topic"
 prompt = """
+Before starting, activate the 'slidev' skill.
+
 I want to generate a set of slides based on a topic or outline.
 
 1. **Information Gathering**:
@@ -9,15 +11,19 @@ I want to generate a set of slides based on a topic or outline.
 2. **Planning**:
    - Structure a logical flow (Cover -> Table of Contents -> Key Concepts -> Examples -> Conclusion).
 
-3. **Generation**:
+3. **Generation (v52+ Standard)**:
    - Create or overwrite 'slides.md' with high-quality content.
    - Start with Frontmatter including theme, title, and UnoCSS configurations.
    - Use a mix of layouts: 'cover', 'two-cols', 'image-left', 'image-right', 'center'.
-   - **Advanced Features**:
-     - Integrate `<v-click>` or `<v-clicks>` for all list items.
+   
+   - **Advanced Feature: Automatic Clicks**:
+     - For ALL lists (ul, ol), wrap them in a container with the `v-clicks` directive (e.g., `<ul v-clicks> ... </ul>`) to automatically animate each item on click.
+     - Avoid using `<v-click>` item-by-item to keep the source code clean.
+   
+   - **Other Features**:
      - Use `v-motion` for smooth entrance of key elements.
-     - Suggest using local images in the `/public/` directory (e.g., `src: /my-image.png`).
      - Add speaker notes in HTML comments for each slide.
      - Use code blocks with multi-step line highlighting for technical slides.
-"""
 
+User specific request: {{args}}
+"""


### PR DESCRIPTION
## Summary
This PR adds the /slidev:format command and expands generation/editing capabilities to include modern Slidev v52+ directives.

## Changes
- Created commands/slidev/format.toml to automate Prettier execution.
- Updated generate.toml to prioritize -clicks for parent containers, resulting in cleaner Markdown source.
- Updated edit.toml to include support for the -mark highlighter directive.
- Integrated the 'slidev' skill activation into the new and updated commands.

Closes #7.