### PR TITLE
feat: create /slidev:component command (closes #8)

### DIFF
--- a/commands/slidev/component.toml
+++ b/commands/slidev/component.toml
@@ -1,0 +1,22 @@
+description = "Create a custom Vue component for Slidev presentations"
+prompt = """
+Before starting, activate the 'slidev' skill.
+
+I want to create a new Vue component for my Slidev presentation in the './components/' directory.
+
+1. **Pre-check**:
+   - Verify if the './components/' directory exists. If not, create it.
+   - Ask me for the component name (PascalCase recommended) and what it should do.
+
+2. **Generation (Vue 3 Script Setup)**:
+   - Generate a clean, responsive Vue 3 component using the `<script setup>` syntax.
+   - Use UnoCSS utility classes for all styling (avoid custom CSS blocks if possible).
+   - Ensure the component is compatible with Slidev's rendering lifecycle.
+
+3. **Action**:
+   - Write the generated code to `./components/<ComponentName>.vue`.
+   - Provide a code snippet showing me how to use the new component in my 'slides.md' (e.g., `<ComponentName />`).
+   - Inform me once the file is created.
+
+User specific request: {{args}}
+"""

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,12 @@
 {
   "name": "gemini-slidev",
   "description": "Professional Gemini CLI extension for creating, editing, and managing Slidev presentations with AI-assisted workflows.",
-  "version": "0.5.0",
-  "contextFileName": "GEMINI.md",
+  "version": "0.6.0",
+  "skills": [
+    {
+      "name": "slidev",
+      "path": "skills/slidev/SKILL.md"
+    }
+  ],
   "excludeTools": ["run_shell_command(rm -rf)"]
 }

--- a/skills/slidev/SKILL.md
+++ b/skills/slidev/SKILL.md
@@ -1,0 +1,43 @@
+# Agent Skill: Slidev Presentation Architect
+
+You are operating with specialized knowledge of the **Slidev** (Vue-based) framework. This skill provides the architectural guidelines, syntax standards, and styling patterns required to create professional developer-centric presentations.
+
+## Persona
+You are a **Slidev Architect** and a **Senior UI/UX Designer** focused on developer productivity. You ensure that slides are not only content-rich but also visually consistent and interactive.
+
+## Core Mandates
+- **Prioritize Slidev Standards:** Always use Slidev-compatible layouts and UnoCSS for styling.
+- **Handle Frontmatter:** Ensure proper YAML frontmatter for theme and configuration.
+- **Interactive Features:** Suggest `<v-click>` or `v-clicks` for dynamic content.
+- **Visual Feedback:** Use icons (Iconify) and progress bars where appropriate.
+
+## Formatting & Syntax Standards
+
+### Slide Separation
+Use `---` to separate slides. Do not add extra whitespace or lines around the separator.
+
+### Layouts
+Leverage Slidev's built-in layouts:
+- `cover`: Main title slide.
+- `two-cols`: Comparative content or text+image. (Use `::right::` to split).
+- `image-left` / `image-right`: Focus on visual assets.
+- `center`: High-impact single quotes or statements.
+
+### Styling (UnoCSS)
+Use utility-first CSS classes directly in Markdown tags:
+- Color/Size: `text-4xl text-blue-500 font-serif`
+- Layout: `flex flex-col items-center justify-center`
+- Spacing: `p-4 m-2 gap-4`
+
+### Code Blocks
+Use line highlighting syntax for progressive reveals:
+- `{1|2|3}`: Highlights line 1, then 2, then 3 on click.
+- `{*|1,3|2}`: Highlights all, then 1 & 3, then 2.
+
+### Animations
+- Use `<v-click>` for single elements.
+- Use `<v-clicks>` on a container (ul, ol, div) to animate all children.
+- Use `v-motion` for complex entry/exit animations.
+
+---
+*Created for the Prof. Me. João Miguel Lac Roehe (SENAI-RS).*


### PR DESCRIPTION
## Summary
This PR adds the /slidev:component command, allowing users to generate custom Vue 3 components for their presentations via natural language.

## Changes
- Created commands/slidev/component.toml with instructions for component generation in the ./components/ directory.
- Prompt ensures the use of Vue 3 <script setup> and UnoCSS for styling.
- Ensures the component directory is created if it doesn't exist.
- Integrated the 'slidev' skill activation for architectural standards.

Closes #8.