### PR TITLE
docs: Sync documentation and governance post-Phase 2 (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ A professional Gemini CLI extension for creating, editing, and managing [Slidev]
 - **➕ Seamless Addition**: Insert new slides intelligently into existing decks.
 - **📤 Production Export**: Export to PDF/PNG with support for animation steps (`--with-clicks`).
 - **▶️ Dev Server**: Integrated control for starting the local preview server.
+- **🧩 Vue Components Creator**: Automatically generate `/components/Name.vue` files for richer visuals via `/slidev:component`.
+- **🗣️ Auto-Speaker Notes**: AI writes robust presenter notes directly as HTML comments via `/slidev:notes`.
+- **🧹 Auto format**: Exposure of the new `/slidev:format` CLI feature using Prettier.
+- **🧠 Agent Skills Architecture**: Uses robust `skills/slidev/SKILL.md` for context instead of a global context file.
 
-### 🚀 Coming Soon (Fase 2)
+### 🚀 Coming Soon (Fase 3)
 
-- **Vue Components Creator:** Automatically generate `/components/Name.vue` files for richer visuals.
-- **Auto-Speaker Notes:** AI will write robust presenter notes directly as HTML comments.
 - **Web Export & Deploy:** One-click `slidev build` and automated deployments.
-- **Agent Skills Migration:** Converting global context to robust `skills/slidev/SKILL.md` (Slidev v52+ standard).
-- **Auto format:** Exposure of the new `/slidev:format` CLI feature.
+- **Slidev v53+ Features:** Integration with newer Slidev capabilities.
 
 ## 📋 Prerequisites
 
@@ -110,7 +111,7 @@ The extension provides a suite of commands for the entire presentation lifecycle
 
 ### Core Principles
 
-This extension adheres to strict quality standards defined in `GEMINI.md`:
+This extension adheres to strict quality standards defined in its Agent Skill (`skills/slidev/SKILL.md`):
 
 - **Markdown-Centric**: Treats `slides.md` as the source of truth.
 - **Component-Driven**: Leverages Slidev's built-in layouts and Vue components.
@@ -146,6 +147,13 @@ This project (formerly `gemini-slidev-extension-contrib`) evolved into its own i
 ## 🤝 Contributing
 
 1. Fork the repository
+2. Create a feature branch
+3. Submit a pull request
+
+## 📄 Legal
+
+- **License**: [Apache License 2.0](LICENSE)
+
 2. Create a feature branch
 3. Submit a pull request
 

--- a/management/HANDOVER.md
+++ b/management/HANDOVER.md
@@ -8,27 +8,30 @@
 - **A Transição:** Percebemos que o laboratório original (`gemini-slidev-extension-contrib`) devia ser preservado eternamente como material didático da Masterclass v5.1. Portanto, esta extensão de software foi promovida a um repositório "Detached" para se tornar um produto focado (gemini-slidev-pro), passível de ser submetido globalmente à Galeria de Extensões do Gemini de forma independente e com o Prof. João como mantenedor central.
 - **O Novo Agente:** A operação de engenharia agora deixa de ser via prompt iterativo cru na CLI e passa a ser orquestrada massivamente pelo próprio **Antigravity**.
 
-## 🔬 Estado Atual (Diagnóstico Herdado)
-A extensão é extremamente funcional, baseada unicamente no contexto fornecido pelo `GEMINI.md` e em arquivos `.toml` definindo custom commands. **Porém**, uma auditoria baseada na documentação de padrões apontou quebras graves na fundação para ela ser "oficial":
+## 🔬 Estado Atual (Diagnóstico Atualizado)
+A extensão é extremamente funcional e agora opera através do sistema robusto de **Agent Skills** (`skills/slidev/SKILL.md`). A fundação foi corrigida e a extensão está oficialmente estruturada como um produto independente (gemini-slidev-pro).
 
 1. **Manifesto (`gemini-extension.json`):**
-   - O campo `"name": "slidev"` desrespeita a regra de refletir o nome do diretório do projeto.
-   - A chave `"entryPoint": "GEMINI.md"` não existe nas regras novas (deveria ser `"contextFileName": "GEMINI.md"` ou simplesmente omitida pois carrega automatico).
-   - Há uma chave inventada `"identifier": "slidev-assistant"` a ser extirpada.
+   - Refatorado para remover o contexto global e registrar a nova Skill.
+   - Versão atualizada e limpa de dependências mortas.
 2. **Sistema de Comandos (`commands/*.toml`):**
-   - Foram nomeados recursivamente como `slidev.init.toml`. Segundo as best practices, o próprio diretório cuida do namespace. É preciso limpar os nomes para `init.toml`, `generate.toml`, etc.
+   - Comandos refatorados e isolados corretamente (`init.toml`, `generate.toml`, etc.).
 
 ## 🎯 Objetivos de Curto Prazo (Nosso Backlog aqui no Novo Lar)
 
-### Fase 1: Limpeza e Conserto Estrutural (Foundation)
-- [ ] Ler as documentações que trouxemos na bagagem do repo antigo para entender o *schema* padrão.
-- [ ] Refatorar imediatamente o `gemini-extension.json` alinhando com a norma mais restrita do sistema Gemini CLI.
-- [ ] Renomear e revisar as nomenclaturas e fluxos do diretório `/commands`.
-- [ ] Modificar referências antigas no `README.md` destacando a emancipação total do projeto e honrando *QIanGua*.
+### ✅ Fase 1: Limpeza e Conserto Estrutural (Foundation)
+- [x] Ler as documentações que trouxemos na bagagem do repo antigo para entender o *schema* padrão.
+- [x] Refatorar imediatamente o `gemini-extension.json` alinhando com a norma mais restrita do sistema Gemini CLI.
+- [x] Renomear e revisar as nomenclaturas e fluxos do diretório `/commands`.
+- [x] Modificar referências antigas no `README.md` destacando a emancipação total do projeto e honrando *QIanGua*.
 
-### Fase 2: Power Plugins (Inovação Radical)
-- [ ] **Criar Criador de Componentes Vue:** Um prompt que instrua perfeitamente a IA gerar arquivos em `/components/Nome.vue` para gráficos e elementos visuais dentro das apresentações.
-- [ ] **Modo Roteirista (Speaker Notes):** Fazer a IA escanear o deck, equilibrar a narrativa e auto-preencher os comentários em HTML de cada tela.
+### ✅ Fase 2: Power Plugins (Concluída)
+- [x] **Criar Criador de Componentes Vue:** Implementado via `/slidev:component`.
+- [x] **Modo Roteirista (Speaker Notes):** Implementado via `/slidev:notes`.
+- [x] **Agent Skills Migration:** Implementado via `skills/slidev/SKILL.md`.
+- [x] **Auto format:** Implementado via `/slidev:format`.
+
+### 🚀 Fase 3: Web & Deploy
 - [ ] **Subida Web:** Implementar via instrução a possibilidade automatizada rápida de realizar `slidev build` e instruir setup no GitHub Pages/Vercel.
 
 ---

--- a/management/WORKFLOW.md
+++ b/management/WORKFLOW.md
@@ -8,8 +8,8 @@
   Para que qualquer IA (Gemini CLI, GitHub Copilot Web/Mobile, Antigravity) opere corretamente, a hierarquia de contexto deve ser
   respeitada:
 
-   1. GEMINI.md (A Fonte Única da Verdade): Contém as regras de arquitetura, padrões de código e exemplos de prompts.
-   2. .github/copilot-instructions.md (O Escudo do Copilot): Um arquivo curto que obriga o Copilot a ler o GEMINI.md antes de
+   1. Agent Skills (`skills/slidev/SKILL.md`): A Fonte Única da Verdade para este projeto, ativada sob demanda. Contém as regras de arquitetura, padrões de código e diretivas do Slidev.
+   2. .github/copilot-instructions.md (O Escudo do Copilot): Um arquivo curto que obriga o Copilot a ler o arquivo de Skill antes de
       qualquer ação.
    3. management/ (O Cérebro Administrativo): Onde os planos de intenção e relatórios de auditoria residem.
 
@@ -25,19 +25,24 @@
 * Dica IA: Se estiver no celular, descreva o problema e peça ao Copilot: "Crie uma Issue no padrão Conventional Commits para este
      problema".
 
-  1. Estratégia (Implementation Plan)
+  2. Estratégia (Implementation Plan)
 
 * Ação: Antes de codar, a IA deve criar um plano em management/plans/feature-name.md.
 * Conteúdo: O plano deve conter: Contexto, Checklist, Detalhes Passo-a-Passo e Critérios de Aceite.
 * Validação: Você revisa o plano. Não há código sem plano aprovado.
 
-  1. Execução (Branch & Code)
+  3. Execução (Branch & Code)
 
 * Ação: Crie uma branch específica (feat/... ou fix/...).
 * Padrão: Use Conventional Commits (ex: feat: add robust check to init command).
-* Blindagem: Se a IA tentar usar TypeScript ou bibliotecas externas, o GEMINI.md deve ser citado para correção de rota.
+* Blindagem: Se a IA tentar usar TypeScript ou bibliotecas externas, o `SKILL.md` deve ser citado para correção de rota.
 
-  1. Revisão e Documentação (PR & Comments)
+  4. Validação (Testes)
+
+* Ação: Execute `npm test` antes de enviar o PR.
+* Ferramenta: O repositório usa o **Vitest** (`tests/`) para garantir a integridade dos arquivos e da sintaxe `.toml`.
+
+  5. Revisão e Documentação (PR & Comments)
 
 * Ação: Abra o Pull Request.
 * Tratamento de Erros: Se uma ideia ou branch falhar, documente o erro no comentário do PR antes de fechá-lo. Isso cria memória
@@ -50,7 +55,7 @@
 
   Copie estes blocos para os respectivos arquivos no novo repositório para manter a blindagem:
 
-  Em GEMINI.md:
+  Em `skills/slidev/SKILL.md`:
 
    1 # AI ASSISTANT INSTRUCTIONS (CRITICAL)
    2 > Este repositório é uma **Gemini CLI Extension**, NÃO uma extensão de VS Code.
@@ -60,7 +65,7 @@
   Em .github/copilot-instructions.md:
 
    1 # Copilot Mandate
-   2 Você DEVE ler e seguir rigorosamente as regras arquiteturais definidas no arquivo `GEMINI.md` na raiz deste projeto antes de
+   2 Você DEVE ler e seguir rigorosamente as regras arquiteturais definidas no arquivo `skills/slidev/SKILL.md` deste projeto antes de
      sugerir qualquer alteração. Este projeto usa TOML para comandos CLI.
 
   ---


### PR DESCRIPTION
## Summary
Updates the documentation to reflect the completion of Phase 2 features and the architectural shift to Agent Skills.

## Changes
- **README.md**: Moved Phase 2 features to the active list and updated technical details to reference \skills/slidev/SKILL.md\.
- **WORKFLOW.md**: Updated the 'Three Pillars of Truth' and the 'Golden Cycle' to reflect the new SKILL file and the inclusion of \
pm test\ in the workflow.
- **HANDOVER.md**: Marked Phase 2 as completed and updated the current diagnostic to reflect the independent product status.

Closes #14.